### PR TITLE
DATAMAKER-1306 시퀀셜 데이터에 대한 데이터 유닛의 체크섬 계산 방식 변경

### DIFF
--- a/datamaker/client/mixins/dataset.py
+++ b/datamaker/client/mixins/dataset.py
@@ -67,6 +67,11 @@ class DatasetClientMixin:
                         data['meta'] = {'max_index': max_index}
                     batch_sequential.append(data_sequential)
 
+            # sequential 데이터에 대한 데이터 유닛 checksum 계산 방식 변경
+            for dict_sequential in batch_sequential:
+                for item_name, item_list in dict_sequential.items():
+                    batch[0]['files'][item_name] = item_list[0]
+
             data_units = self.create_data_units(batch)
 
             if batch_sequential:

--- a/datamaker/client/mixins/dataset.py
+++ b/datamaker/client/mixins/dataset.py
@@ -57,8 +57,9 @@ class DatasetClientMixin:
                                 file
                             ), 'The number of files must be the same.'
 
+                # sequential 데이터의 경우 첫 파일이 체크섬 계산에 포함되도록 처리
                 for name in names_to_remove:
-                    del data['files'][name]
+                    data['files'][name] = data['files'][name][0]
 
                 if data_sequential:
                     try:
@@ -66,11 +67,6 @@ class DatasetClientMixin:
                     except KeyError:
                         data['meta'] = {'max_index': max_index}
                     batch_sequential.append(data_sequential)
-
-            # sequential 데이터에 대한 데이터 유닛 checksum 계산 방식 변경
-            for dict_sequential in batch_sequential:
-                for item_name, item_list in dict_sequential.items():
-                    batch[0]['files'][item_name] = item_list[0]
 
             data_units = self.create_data_units(batch)
 

--- a/datamaker/client/mixins/dataset.py
+++ b/datamaker/client/mixins/dataset.py
@@ -61,6 +61,9 @@ class DatasetClientMixin:
                                 file
                             ), 'The number of files must be the same.'
 
+                for name in names_to_remove:
+                    del data['files'][name]
+
                 if data_sequential:
                     try:
                         data['meta']['max_index'] = max_index

--- a/datamaker/client/mixins/dataset.py
+++ b/datamaker/client/mixins/dataset.py
@@ -26,6 +26,10 @@ class DatasetClientMixin:
         path = 'data_unit_files/'
         return self._post(path, payload=data)
 
+    def calculate_checksum(self, pk):
+        path = f'data_units/{pk}/calculate_checksum/'
+        return self._get(path)
+
     def import_dataset(
         self, dataset_id, dataset, project_id=None, batch_size=1000, process_pool=10
     ):

--- a/datamaker/client/mixins/dataset.py
+++ b/datamaker/client/mixins/dataset.py
@@ -61,10 +61,6 @@ class DatasetClientMixin:
                                 file
                             ), 'The number of files must be the same.'
 
-                # sequential 데이터의 경우 첫 파일이 체크섬 계산에 포함되도록 처리
-                for name in names_to_remove:
-                    data['files'][name] = data['files'][name][0]
-
                 if data_sequential:
                     try:
                         data['meta']['max_index'] = max_index
@@ -82,6 +78,8 @@ class DatasetClientMixin:
                             'name': name,
                             'files': files,
                         })
+                    # update checksum
+                    self.calculate_checksum(data_unit['id'])
 
             if project_id:
                 labels_data = []


### PR DESCRIPTION
- sequential 데이터와 일반 데이터를 같이 임포트하는 경우 둘 중 하나의 데이터 종류는 고정되는 경우가 있어 새로운 데이터 유닛이 만들어지지 않는 문제가 있었습니다.
- create_data_units에 들어가는 batch에 sequential 데이터의 일부를 포함하여 새로 만들도록 만들었습니다.
- 일부만 넣은 이유는 다음과 같습니다.
1. 한번에 넣으면 데이터의 양이 너무 많아지는 문제가 발생할 수 있음. 
2. 어차피 sequential, 일반 데이터 둘 중 하나만 변화하는 값이어도 checksum이 달라지기 때문.