### PR TITLE
[bugfix] top-level linter 오류 해결

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,9 @@ build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]
 
-[tool.ruff]
+[lint.ruff]
 select = ['E', 'F', 'Q']
 ignore = ['W191', 'E111', 'E114', 'E117', 'D206', 'D300', 'Q000', 'Q001', 'Q002', 'Q003', 'COM812', 'COM819', 'ISC001', 'ISC002']
 
-[tool.ruff.format]
+[lint.ruff.format]
 quote-style = 'single'
-preview = true
-
-[tool.ruff.pydocstyle]
-convention = 'google'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,14 @@
+[build-system]
+requires = [
+    'setuptools >= 42',
+    'wheel',
+    'setuptools_scm[toml]>=6.2'
+]
+build-backend = 'setuptools.build_meta'
+
 [tool.setuptools_scm]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ['E', 'F', 'Q']
 ignore = ['W191', 'E111', 'E114', 'E117', 'D206', 'D300', 'Q000', 'Q001', 'Q002', 'Q003', 'COM812', 'COM819', 'ISC001', 'ISC002']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,12 @@
-[build-system]
-requires = [
-    'setuptools >= 42',
-    'wheel',
-    'setuptools_scm[toml]>=6.2'
-]
-build-backend = 'setuptools.build_meta'
-
 [tool.setuptools_scm]
 
-[lint.ruff]
+[tool.ruff]
 select = ['E', 'F', 'Q']
 ignore = ['W191', 'E111', 'E114', 'E117', 'D206', 'D300', 'Q000', 'Q001', 'Q002', 'Q003', 'COM812', 'COM819', 'ISC001', 'ISC002']
 
-[lint.ruff.format]
+[tool.ruff.format]
 quote-style = 'single'
+preview = true
+
+[tool.ruff.pydocstyle]
+convention = 'google'


### PR DESCRIPTION
- 현재 ruff애서 아래와 같은 오류가 발생합니다.
- warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`: 오류를 해결하기 위한 pr입니다.