### PR TITLE
SYN-737 할당 작업에 태그를 부착할 수 있는 api를 sdk에 포함하기

### DIFF
--- a/datamaker/client/mixins/hitl.py
+++ b/datamaker/client/mixins/hitl.py
@@ -6,7 +6,7 @@ class HITLClientMixin:
     def list_assignments(self, payload=None):
         path = 'assignments/'
         return self._list(path, payload)
-    
+
     def set_tags_assignments(self, data, params=None):
         path = 'assignments/set_tags/'
         return self._post(path, payload=data, params=params)

--- a/datamaker/client/mixins/hitl.py
+++ b/datamaker/client/mixins/hitl.py
@@ -10,3 +10,4 @@ class HITLClientMixin:
     def set_tags_assignments(self, data, params=None):
         path = 'assignments/set_tags/'
         return self._post(path, payload=data, params=params)
+

--- a/datamaker/client/mixins/hitl.py
+++ b/datamaker/client/mixins/hitl.py
@@ -6,3 +6,7 @@ class HITLClientMixin:
     def list_assignments(self, payload=None):
         path = 'assignments/'
         return self._list(path, payload)
+    
+    def set_tags_assignments(self, data, params=None):
+        path = 'assignments/set_tags/'
+        return self._post(path, payload=data, params=params)

--- a/datamaker/client/mixins/hitl.py
+++ b/datamaker/client/mixins/hitl.py
@@ -10,4 +10,3 @@ class HITLClientMixin:
     def set_tags_assignments(self, data, params=None):
         path = 'assignments/set_tags/'
         return self._post(path, payload=data, params=params)
-


### PR DESCRIPTION
### 개요
- 할당작업 태그를 부착할 수 있는 api를 추가하였습니다.
- 관련 지라 : https://datamaker.atlassian.net/browse/SYN-737

### 설명
 - 몇몇 프로젝트(주로 프롬프트)의 custom script에 활용하기 위함입니다.